### PR TITLE
다이얼로그 수정

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/lib/src/components/dialog_b.dart
+++ b/lib/src/components/dialog_b.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:recycle_dialog/src/widget_c.dart';
+import '../components/radio_select.dart';
 
 class DialogB extends StatelessWidget {
   final bool isFinished;
@@ -13,7 +14,7 @@ class DialogB extends StatelessWidget {
         height: 300,
         child: Column(
           children: [
-            Text("DIALOG"),
+            Container(child: RadioGroupWidget(feedback: '')),
             TextField(),
             isFinished
                 ? RaisedButton(

--- a/lib/src/components/radio_select.dart
+++ b/lib/src/components/radio_select.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+class RadioGroupWidget extends StatefulWidget {
+  final String feedback;
+
+  const RadioGroupWidget({this.feedback});
+
+  @override
+  _RadioGroupWidgetState createState() => _RadioGroupWidgetState(feedback);
+}
+
+class _RadioGroupWidgetState extends State<RadioGroupWidget> {
+  String feedback;
+  _RadioGroupWidgetState(this.feedback);
+  String selectGroup;
+
+  @override
+  void initState() {
+    super.initState();
+    selectGroup = feedback;
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  setSelectedRadioTile(String val) {
+    setState(() {
+      selectGroup = val;
+      print('setSelectedRadioTile : $selectGroup');
+    });
+  }
+
+  Widget build(BuildContext context) {
+    return Column(
+      children: <Widget>[
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8.0),
+          child: Row(
+            children: [
+              Radio<String>(
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  groupValue: selectGroup,
+                  value: '1',
+                  onChanged: (String newValue) {
+                    setSelectedRadioTile(newValue);
+                  }),
+              Expanded(
+                child: RichText(
+                  text: TextSpan(
+                    style: TextStyle(color: Colors.black),
+                    text: '선택지1',
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () {
+                        setSelectedRadioTile('1');
+                      },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8.0),
+          child: Row(
+            children: [
+              Radio<String>(
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  groupValue: selectGroup,
+                  value: '2',
+                  onChanged: (String newValue) {
+                    setSelectedRadioTile(newValue);
+                  }),
+              Expanded(
+                child: RichText(
+                  text: TextSpan(
+                    style: TextStyle(color: Colors.black),
+                    text: '선택지2',
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () {
+                        setSelectedRadioTile('2');
+                      },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8.0),
+          child: Row(
+            children: [
+              Radio<String>(
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  groupValue: selectGroup,
+                  value: '3',
+                  onChanged: (String newValue) {
+                    setSelectedRadioTile(newValue);
+                  }),
+              Expanded(
+                child: RichText(
+                  text: TextSpan(
+                    style: TextStyle(color: Colors.black),
+                    text: '선택지3',
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () {
+                        setSelectedRadioTile('3');
+                      },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8.0),
+          child: Row(
+            children: [
+              Radio<String>(
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  groupValue: selectGroup,
+                  value: '4',
+                  onChanged: (String newValue) {
+                    setSelectedRadioTile(newValue);
+                  }),
+              Expanded(
+                child: RichText(
+                  text: TextSpan(
+                    style: TextStyle(color: Colors.black),
+                    text: '선택지4',
+                    recognizer: TapGestureRecognizer()
+                      ..onTap = () {
+                        setSelectedRadioTile('4');
+                      },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
안녕하세요
말씀하신 화면전환이 맞습니다.

좀 더 예시가 편하도록 다이얼로그에 라디오선택지를 추가했습니다.

WidgetA에서 Show Dialog를 했을때 고를수 있는 선택지를 선택한 뒤
route widget_c를 클릭 -> WidgetC화면으로 전환됩니다
이후 Show Dialog를 하면 기존에 띄워놨던 다이얼로그를 그대로 뿌려주고 싶지만 새로운 다이얼로그가 표시됩니다. (선택한 값이 보이지 않음)

마찬가지로 여기서 값을 선택한 뒤 WidgetA로 넘어가면 A화면에서 띄운 다이얼로그는 남아있지만 선택지는 변경되어 있지 않습니다.

새로운 위젯을 만든거다보니 당연한 흐름이긴 한데.. 가려져있던 다이얼로그를 그냥 위로 올리는건 안되는건지.. 안된다면 bloc로 처리해야하는지 궁금합니다.